### PR TITLE
Fix app.nexusgraph.com server config issue

### DIFF
--- a/hashicorp/images/nginx-ssl-app.conf
+++ b/hashicorp/images/nginx-ssl-app.conf
@@ -20,7 +20,7 @@ server {
     server_name app.nexusgraph.com;
 
 	location / {
-		proxy_pass http://localhost:9000;
+		proxy_pass http://127.0.0.1:9000;
 	}
 
     listen [::]:443 ssl ipv6only=on;

--- a/hashicorp/instances/app.tf
+++ b/hashicorp/instances/app.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "nexusgraph-app" {
   user_data = <<-EOF
     #!/bin/bash
     cd /home/ubuntu/nexusgraph/dist
-    python3 -m http.server 9000
+    python3 -m http.server 9000 --bind 127.0.0.1
   EOF
 }
 


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

- nexusgraph 部署到 `app.nexusgraph.com` 之后，HTTPS 请求没有被 Nginx 反向代理正确转发，需要显式地指明绑定 loop back 地址为 127.0.0.1 才行（这个之前没有遇到过，因为之前用的 `localhost` 在 Windows 服务器上是没问题的）

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
