### PR TITLE
Backpressuring Theresa requests

### DIFF
--- a/packages/nexusgraph-editor/src/Lexical/plugins/NexusgraphOnChangePlugin.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/plugins/NexusgraphOnChangePlugin.tsx
@@ -28,24 +28,24 @@ export default function NexusgraphOnChangePlugin(): null {
   const naturalLanguageProcessor = new RemoteNaturalLanguageProcessor();
   const dispatch = useDispatch();
 
-  let editorLines: string[] = []
+  let editorLines: string[] = [];
 
   useEffect(() => {
     const updateGraph = () => {
       if (editorLines.length > 0) {
-        const entityExtrationTexts: string[] = structuredClone(editorLines)
-        editorLines = []
+        const entityExtrationTexts: string[] = structuredClone(editorLines);
+        editorLines = [];
         naturalLanguageProcessor.entityExtraction(entityExtrationTexts).then((graphEditorState) => {
           dispatch({ type: UPDATE_GRAPH, payload: graphEditorState });
         });
       }
-    }
+    };
 
     const t = setInterval(updateGraph, 5000);
 
     return () => clearInterval(t);
-  }, []) 
-  
+  }, []);
+
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState }) => {
       editorState.read(() => {

--- a/packages/nexusgraph-editor/src/Lexical/plugins/NexusgraphOnChangePlugin.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/plugins/NexusgraphOnChangePlugin.tsx
@@ -27,16 +27,30 @@ export default function NexusgraphOnChangePlugin(): null {
   const [editor] = useLexicalComposerContext();
   const naturalLanguageProcessor = new RemoteNaturalLanguageProcessor();
   const dispatch = useDispatch();
+
+  let editorLines: string[] = []
+
+  useEffect(() => {
+    const updateGraph = () => {
+      if (editorLines.length > 0) {
+        const entityExtrationTexts: string[] = structuredClone(editorLines)
+        editorLines = []
+        naturalLanguageProcessor.entityExtraction(entityExtrationTexts).then((graphEditorState) => {
+          dispatch({ type: UPDATE_GRAPH, payload: graphEditorState });
+        });
+      }
+    }
+
+    const t = setInterval(updateGraph, 5000);
+
+    return () => clearInterval(t);
+  }, []) 
+  
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState }) => {
       editorState.read(() => {
         const jsonObject = JSON.parse(JSON.stringify(editor.getEditorState()));
-        const editorLines: string[] = parse(jsonObject);
-        if (editorLines.length > 0) {
-          naturalLanguageProcessor.entityExtraction(editorLines).then((graphEditorState) => {
-            dispatch({ type: UPDATE_GRAPH, payload: graphEditorState });
-          });
-        }
+        editorLines = parse(jsonObject);
       });
     });
   }, [editor, parse, dispatch]);


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- 为了减少编辑器过于频繁请求 Theresa，现在编辑器**每 5 秒**向 Theresa 发送分析请求，并且能**保证抓取用户的最后一次编辑**进行分析，具体原理是 在 NexusgraphOnChangePlugin mount 完毕之后使用一个仅执行一次的 useEffect 来启用 [setInterval()](https://developer.mozilla.org/en-US/docs/Web/API/setInterval)

> 为了[分步实现](https://blog.codacy.com/small-pull-requests)编辑器优雅地和用户交互，我们后面还有 2 个 follow-up PR's:
> 
> 1. [将 “5 秒” 变成启动配置参数](https://trello.com/c/mpleLMT8)
> 2. [将配置参数实现成用户可以在页面修改](https://trello.com/c/2jrVKlO1)

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
