### PR TITLE
Use bracket notation to avoid false-negative type checking at compile time

### DIFF
--- a/packages/nexusgraph-editor/src/Lexical/processor/RemoteNaturalLanguageProcessor.test.ts
+++ b/packages/nexusgraph-editor/src/Lexical/processor/RemoteNaturalLanguageProcessor.test.ts
@@ -9,7 +9,7 @@ const naturalLanguageProcessor = new RemoteNaturalLanguageProcessor();
 describe("Remote Natural Language Processor can transform Knowledge Graph Spec data into the format needed by graphing component", () => {
   test("Empty WS response converts to an empty Redux state", async () => {
     const editorLines: any = [];
-    expect(naturalLanguageProcessor.getBasicNode(editorLines)).toEqual([]);
+    expect(naturalLanguageProcessor["getBasicNode"](editorLines)).toEqual([]);
   });
 
   it("processor converts Knowledge Graph spec data into Redux states", () => {
@@ -39,7 +39,7 @@ describe("Remote Natural Language Processor can transform Knowledge Graph Spec d
       ],
     };
 
-    expect(naturalLanguageProcessor.getBasicNode(dataGiven)).toEqual([
+    expect(naturalLanguageProcessor["getBasicNode"](dataGiven)).toEqual([
       { id: "中国", labels: ["Location"], properties: { name: "中国" }, propertyTypes: { name: "string" } },
       { id: "6", labels: ["Quantity"], properties: { name: "6" }, propertyTypes: { name: "string" } },
       { id: "6", labels: ["Quantity"], properties: { name: "6" }, propertyTypes: { name: "string" } },
@@ -61,7 +61,7 @@ describe("Remote Natural Language Processor delegates processing to remote WS", 
     };
     Object(axios.get).mockResolvedValueOnce(user);
 
-    naturalLanguageProcessor.fetchRemote(editorLines).then((graphEditorState) => {
+    naturalLanguageProcessor["fetchRemote"](editorLines).then((graphEditorState) => {
       expect(graphEditorState).toEqual(user);
 
       expect(axios.get).toHaveBeenCalledWith(process.env.ENTITY_EXTRACTION_API, {


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- 之前在测试中访问 private member 使用的是 dot notation，这样会有编译报错，但实际上这是不影响测试运行的：

  <img width="1022" alt="page" src="https://github.com/paion-data/nexusgraph/assets/16126939/e6ab6f98-dcf3-4575-9dd7-34b62dd115eb">

  TypeScript 支持[专门针对测试的 "bracket notation"，可以避免这样的报错](https://www.typescriptlang.org/docs/handbook/2/classes.html#caveats)：

  <img width="1014" alt="page 1" src="https://github.com/paion-data/nexusgraph/assets/16126939/d5538229-8562-4a85-84ca-6d1f43d4e2eb">



### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
