### PR TITLE
Removing import React from "react"

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,7 +1,6 @@
 /*
  * Copyright 2023 Paion Data. All rights reserved.
  */
-import React from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,6 +1,7 @@
 /*
  * Copyright 2023 Paion Data. All rights reserved.
  */
+import React from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";

--- a/packages/nexusgraph-app/src/index.tsx
+++ b/packages/nexusgraph-app/src/index.tsx
@@ -2,7 +2,6 @@
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
-import React from "react";
 import { Provider } from "react-redux";
 import { configureStore, combineReducers } from "@reduxjs/toolkit";
 import { GlobalState } from "../../nexusgraph-graph/src/shared/globalState";

--- a/packages/nexusgraph-editor/src/Editor.tsx
+++ b/packages/nexusgraph-editor/src/Editor.tsx
@@ -1,7 +1,6 @@
 /*
  * Copyright 2023 Paion Data. All rights reserved.
  */
-import React from "react";
 import { LexicalEditor } from "./Lexical";
 import editorConfig from "./Lexical/LexicalEditorConfig";
 

--- a/packages/nexusgraph-editor/src/Lexical/LexicalEditor.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/LexicalEditor.tsx
@@ -1,7 +1,4 @@
-/*
- * Copyright 2023 Paion Data. All rights reserved.
- */
-
+// Copyright 2023 Paion Data. All rights reserved.
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
 import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";

--- a/packages/nexusgraph-editor/src/Lexical/LexicalEditor.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/LexicalEditor.tsx
@@ -1,7 +1,6 @@
 /*
  * Copyright 2023 Paion Data. All rights reserved.
  */
-import React from "react";
 
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";

--- a/packages/nexusgraph-graph/src/VisualizationView.tsx
+++ b/packages/nexusgraph-graph/src/VisualizationView.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 import { useSelector } from "react-redux";
 import { GlobalState } from "./shared/globalState";
 import { getEditorNodes, getEditorRelationships } from "./shared/editor/editorDuck";

--- a/packages/nexusgraph-graph/src/WheelZoomInfoOverlay.tsx
+++ b/packages/nexusgraph-graph/src/WheelZoomInfoOverlay.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 
 import {

--- a/packages/nexusgraph-graph/src/inspection-panel/ClickableUrls.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/ClickableUrls.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-
 /* eslint-disable no-alert, no-useless-escape */
 const URL_REGEX =
   /(?:https?|s?ftp|bolt):\/\/(?:(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))?\))+(?:\((?:[^\s()<>]+|(?:\(?:[^\s()<>]+\)))?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))?/gi;

--- a/packages/nexusgraph-graph/src/inspection-panel/ClickableUrls.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/ClickableUrls.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 
 /* eslint-disable no-alert, no-useless-escape */
 const URL_REGEX =

--- a/packages/nexusgraph-graph/src/inspection-panel/NodeLabel.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/NodeLabel.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-
 import { NonClickableLabelChip } from "../styles/DefaultPane.styled";
 import { GraphStyleModel } from "../GraphStyle";
 

--- a/packages/nexusgraph-graph/src/inspection-panel/NodeLabel.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/NodeLabel.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 
 import { NonClickableLabelChip } from "../styles/DefaultPane.styled";
 import { GraphStyleModel } from "../GraphStyle";

--- a/packages/nexusgraph-graph/src/inspection-panel/RelType.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/RelType.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 import { NonClickableRelTypeChip } from "../styles/DefaultPane.styled";
 import { GraphStyleModel } from "../GraphStyle";
 

--- a/packages/nexusgraph-graph/src/inspection-panel/ShowMoreOrAll.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/ShowMoreOrAll.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-
 import { StyledShowMoreButton } from "../styles/StyledShowMoreButton.styled";
 
 interface ShowMoreOrAllProps {

--- a/packages/nexusgraph-graph/src/inspection-panel/ShowMoreOrAll.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/ShowMoreOrAll.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 
 import { StyledShowMoreButton } from "../styles/StyledShowMoreButton.styled";
 

--- a/packages/nexusgraph-graph/src/inspection-panel/WarningMessage.tsx
+++ b/packages/nexusgraph-graph/src/inspection-panel/WarningMessage.tsx
@@ -1,5 +1,4 @@
 // Copyright 2023 Paion Data. All rights reserved.
-import React from "react";
 import styled from "styled-components";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 

--- a/packages/nexusgraph-graph/src/styles/themes.tsx
+++ b/packages/nexusgraph-graph/src/styles/themes.tsx
@@ -1,6 +1,5 @@
 // Copyright 2023 Paion Data. All rights reserved.
 import { ThemeProvider } from "styled-components";
-import React from "react";
 
 export const baseArcTheme = {
   name: "base",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["packages"],
+  "include": ["packages", "**/*.tsx"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

- [We no longer need to import React from 'react'](https://dev.to/titungdup/you-no-longer-need-to-import-react-from-react-3pbj)

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
