### PR TITLE
Write text-input document and test

### DIFF
--- a/packages/nexusgraph-editor/src/Lexical/ui/TextInput.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/TextInput.test.tsx
@@ -1,0 +1,93 @@
+// Copyright 2023 Paion Data. All rights reserved.
+import { describe, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import "@testing-library/jest-dom";
+import TextInput from "./TextInput";
+
+describe("text input DOM test", () => {
+  test("Placeholder defaults to an empty string", () => {
+    render(
+      <TextInput
+        label=""
+        value=""
+        onChange={() => {
+          // do nothing.
+        }}
+        data-testid="default-placeholder-test"
+      />
+    );
+    expect(screen.getByTestId("default-placeholder-test").getAttribute("placeholder")).toBe("");
+  });
+
+  test("Text input displays specified label", () => {
+    render(
+      <TextInput
+        label="my label"
+        value=""
+        onChange={() => {
+          // do nothing.
+        }}
+      />
+    );
+    expect(document.getElementsByClassName("Input__label").length).toBe(1);
+    expect(document.getElementsByClassName("Input__label")[0].textContent).toBe("my label");
+  });
+
+  test("Text input displays specified value", () => {
+    render(
+      <TextInput
+        label=""
+        data-testid="specified-value-test"
+        value="text in input box"
+        onChange={() => {
+          // do nothing.
+        }}
+      />
+    );
+    expect(screen.getByTestId("specified-value-test").getAttribute("value")).toBe("text in input box");
+  });
+
+  test("Text input has the specified data-testid", () => {
+    render(
+      <TextInput
+        label=""
+        value=""
+        data-testid="specified-data-testid"
+        onChange={() => {
+          // do nothing.
+        }}
+      />
+    );
+    expect(screen.getByTestId("specified-data-testid").getAttribute("data-testid")).toBe("specified-data-testid");
+  });
+
+  test("The default type of input is 'text'", () => {
+    render(
+      <TextInput
+        label=""
+        value=""
+        data-testid="default-type-testid"
+        onChange={() => {
+          // do nothing.
+        }}
+      />
+    );
+    expect(screen.getByTestId("default-type-testid").getAttribute("type")).toBe("text");
+  });
+
+  test("Text input displays specified type", () => {
+    render(
+      <TextInput
+        label=""
+        value=""
+        data-testid="specified-type-testid"
+        type="file"
+        onChange={() => {
+          // do nothing.
+        }}
+      />
+    );
+    expect(screen.getByTestId("specified-type-testid").getAttribute("type")).toBe("file");
+  });
+});

--- a/packages/nexusgraph-editor/src/Lexical/ui/TextInput.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/TextInput.tsx
@@ -2,27 +2,50 @@
 import { HTMLInputTypeAttribute } from "react";
 
 type Props = Readonly<{
-  "data-test-id"?: string;
+  /**
+   * An attribute used to identify DOM nodes for [testing](https://testing-library.com/docs/queries/bytestid/)
+   */
+  "data-testid"?: string;
+
+  /**
+   * The [label](https://www.w3schools.com/tags/tag_label.asp) for the wrapped <input> element
+   */
   label: string;
+
+  /**
+   * The regular [onChange](https://www.w3schools.com/jsref/event_onchange.asp) callback function that acts on the contents of the input box
+   */
   onChange: (val: string) => void;
+
+  /**
+   * The [placeholder](https://www.w3schools.com/tags/att_input_placeholder.asp) attribute specifies a short hint that describes the expected value of an input field
+   */
   placeholder?: string;
+
+  /**
+   * The [value](https://www.w3schools.com/tags/att_input_value.asp) attribute specifies the value of an <input> element.
+   */
   value: string;
+
+  /**
+   * The <input> element can be displayed in a variety of ways by [type](https://www.w3schools.com/tags/tag_input.asp),such as checkbox, file, etc.
+   */
   type?: HTMLInputTypeAttribute;
 }>;
 
 /**
- * Render first line of fontcolor dropdown menu
+ * `TextInput` is a wrapper of [HTML input](https://www.w3schools.com/tags/tag_input.asp) and is used in Editor for various form inputs
  *
- * @param param0
+ * @param Props
  *
- * @returns fontcolor dropdown menu first line div
+ * @returns The JSX for text input
  */
 export default function TextInput({
   label,
   value,
   onChange,
   placeholder = "",
-  "data-test-id": dataTestId,
+  "data-testid": dataTestId,
   type = "text",
 }: Props): JSX.Element {
   return (
@@ -36,8 +59,7 @@ export default function TextInput({
         onChange={(e) => {
           onChange(e.target.value);
         }}
-        data-test-id={dataTestId}
-        style={{ color: `${value}` }}
+        data-testid={dataTestId}
       />
     </div>
   );


### PR DESCRIPTION
Changelog
---------

### Added
 - 给TextInput 组件添加文档
 - 给TextInput 组件编写测试
 - 测试点为：

> 1. 实例化一个 TextInput 组件，指定 label，断言渲染出来的 input label 等于指定的 label
> 2. 实例化一个 TextInput 组件，指定 value，断言渲染出来的 input label 等于指定的 value
> 3. 实例化一个 TextInput 组件，指定 placeholder，断言渲染出来的 input label 等于指定的 placeholder
> 4. 实例化一个 TextInput 组件，指定 data-test-id，断言渲染出来的 input label 等于指定的 data-test-id
> 5. 实例化一个 TextInput 组件，不指定 type，断言渲染出来的 input type 等于 “text”
> 6. 实例化一个 TextInput 组件，指定 type，断言渲染出来的 input label 等于指定的 type 

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
