### PR TITLE
Write dropdown document and test

### DIFF
--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
@@ -1,18 +1,113 @@
 // Copyright 2023 Paion Data. All rights reserved.
 import { describe, expect } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import DropDown from "./DropDown";
+import DropDown, { DropDownItem } from "./DropDown";
+
 describe("DropDown DOM test", () => {
-  test("DropDown", () => {
-    render(<DropDown buttonClassName={""} children={undefined} />);
+  test("DropDown displays specified disabled", () => {
+    render(<DropDown disabled={true} stopCloseOnClickSelf buttonClassName={""} children={undefined} />);
     expect(screen.getByRole("button")).toHaveProperty("disabled");
+  });
+
+  test("DropDown displays specified buttonAriaLabel", () => {
+    render(
+      <DropDown
+        disabled={false}
+        stopCloseOnClickSelf
+        buttonAriaLabel={"button"}
+        buttonClassName={""}
+        children={undefined}
+      />
+    );
+    expect(screen.getByRole("button", { name: /button/i })).not.toBeNull;
+  });
+
+  test("DropDown displays specified buttonClassName", () => {
+    render(<DropDown disabled={false} stopCloseOnClickSelf buttonClassName={"button"} children={undefined} />);
+    expect(screen.getByRole("button")).toHaveProperty("className", "button");
+  });
+
+  test("DropDown displays specified buttonIconClassName", () => {
+    render(
+      <DropDown
+        disabled={false}
+        stopCloseOnClickSelf
+        buttonIconClassName={"icon"}
+        buttonClassName={""}
+        children={undefined}
+      />
+    );
+    expect(screen.getByTestId("iconid")).toHaveProperty("className", "icon");
+  });
+
+  test("DropDown displays specified buttonLabel", () => {
+    render(
+      <DropDown
+        disabled={false}
+        stopCloseOnClickSelf
+        buttonIconClassName={""}
+        buttonLabel={"label"}
+        buttonClassName={""}
+        children={undefined}
+      />
+    );
+    expect(screen.getByText("label")).not.toBeNull;
+  });
+
+  test("Mock onClick function in DropDown and be called", () => {
+    const clickevent = jest.fn();
+    render(
+      <DropDown buttonClassName={""}>
+        <DropDownItem children={undefined} className={""} onClick={() => clickevent()} />
+      </DropDown>
+    );
+    expect(clickevent).toHaveBeenCalled;
   });
 });
 
 describe("DropDownItem DOM test", () => {
-  test("DropDownItem", () => {
-    render(<DropDown buttonClassName={""} children={undefined} />);
-    expect(screen.getByRole("button")).toHaveProperty("disabled");
+  test("DropDownItem displays specified title", () => {
+    render(
+      <DropDown buttonClassName={""}>
+        <DropDownItem
+          children={undefined}
+          className={""}
+          title={"title"}
+          onClick={function (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void {
+            throw new Error("Function not implemented.");
+          }}
+        />
+      </DropDown>
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTitle("title")).not.toBeNull;
+  });
+
+  test("DropDownItem displays specified className", () => {
+    render(
+      <DropDown buttonClassName={""}>
+        <DropDownItem
+          children={undefined}
+          className={"button"}
+          title={"title"}
+          onClick={function (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void {
+            throw new Error("Function not implemented.");
+          }}
+        />
+      </DropDown>
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTitle("title")).toHaveProperty("className", "button");
+  });
+
+  test("Mock onClick function in DropDownItem and be called", () => {
+    const clickevent = jest.fn();
+    render(
+      <DropDown buttonClassName={""}>
+        <DropDownItem children={undefined} className={""} onClick={clickevent} />
+      </DropDown>
+    );
+    expect(clickevent).toHaveBeenCalled;
   });
 });

--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
@@ -38,7 +38,7 @@ describe("DropDown DOM test", () => {
         children={undefined}
       />
     );
-    expect(screen.getByTestId("iconid")).toHaveProperty("className", "icon");
+    expect(document.getElementsByClassName("icon")[0].getAttribute("class")).toBe("icon");
   });
 
   test("DropDown displays specified buttonLabel", () => {

--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
@@ -6,67 +6,84 @@ import DropDown, { DropDownItem } from "./DropDown";
 
 describe("DropDown DOM test", () => {
   test("DropDown displays specified disabled", () => {
-    render(<DropDown disabled={true} stopCloseOnClickSelf buttonClassName={""} children={undefined} />);
+    render(<DropDown disabled={true} buttonClassName={""} children={undefined} />);
     expect(screen.getByRole("button")).toHaveProperty("disabled");
   });
 
+  test("DropDown displays specified children", () => {
+    render(<DropDown buttonClassName={""} children={<div data-testid="children" />} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("children")).not.toBeNull;
+  });
+
   test("DropDown displays specified buttonAriaLabel", () => {
-    render(
-      <DropDown
-        disabled={false}
-        stopCloseOnClickSelf
-        buttonAriaLabel={"button"}
-        buttonClassName={""}
-        children={undefined}
-      />
-    );
-    expect(screen.getByRole("button", { name: /button/i })).not.toBeNull;
+    render(<DropDown disabled={false} buttonAriaLabel={"menu"} buttonClassName={""} children={undefined} />);
+    expect(screen.getByRole("button", { name: /menu/i })).not.toBeNull;
   });
 
   test("DropDown displays specified buttonClassName", () => {
-    render(<DropDown disabled={false} stopCloseOnClickSelf buttonClassName={"button"} children={undefined} />);
+    render(<DropDown disabled={false} buttonClassName={"button"} children={undefined} />);
     expect(screen.getByRole("button")).toHaveProperty("className", "button");
   });
 
   test("DropDown displays specified buttonIconClassName", () => {
-    render(
-      <DropDown
-        disabled={false}
-        stopCloseOnClickSelf
-        buttonIconClassName={"icon"}
-        buttonClassName={""}
-        children={undefined}
-      />
-    );
+    render(<DropDown disabled={false} buttonIconClassName={"icon"} buttonClassName={""} children={undefined} />);
     expect(document.getElementsByClassName("icon")[0].getAttribute("class")).toBe("icon");
   });
 
   test("DropDown displays specified buttonLabel", () => {
-    render(
-      <DropDown
-        disabled={false}
-        stopCloseOnClickSelf
-        buttonIconClassName={""}
-        buttonLabel={"label"}
-        buttonClassName={""}
-        children={undefined}
-      />
-    );
+    render(<DropDown disabled={false} buttonLabel={"label"} buttonClassName={""} children={undefined} />);
     expect(screen.getByText("label")).not.toBeNull;
   });
 
-  test("Mock onClick function in DropDown and be called", () => {
-    const clickevent = jest.fn();
+  test("StopCloseOnClickSelf is true, click the basic-color button, and the drop-down box will not disappear", () => {
     render(
-      <DropDown buttonClassName={""}>
-        <DropDownItem children={undefined} className={""} onClick={() => clickevent()} />
-      </DropDown>
+      <DropDown
+        disabled={false}
+        stopCloseOnClickSelf={true}
+        buttonClassName={""}
+        children={<button data-testid="buttonitem" />}
+      />
     );
-    expect(clickevent).toHaveBeenCalled;
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByTestId("buttonitem"));
+
+    expect(document.getElementsByClassName(".dropdown")).not.toBeNull;
+  });
+
+  test("StopCloseOnClickSelf is false, click the basic-color button, and the drop-down box will disappear", () => {
+    render(
+      <DropDown
+        disabled={false}
+        stopCloseOnClickSelf={false}
+        buttonClassName={""}
+        children={<button data-testid="buttonitem" />}
+      />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByTestId("buttonitem"));
+
+    expect(document.getElementsByClassName(".dropdown")).toBeNull;
   });
 });
 
 describe("DropDownItem DOM test", () => {
+  test("DropDownItem displays specified children", () => {
+    render(
+      <DropDown buttonClassName={""}>
+        <DropDownItem
+          children={<div data-testid="children" />}
+          className={""}
+          onClick={function (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void {
+            throw new Error("Function not implemented.");
+          }}
+        />
+      </DropDown>
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("children")).not.toBeNull;
+  });
+
   test("DropDownItem displays specified title", () => {
     render(
       <DropDown buttonClassName={""}>

--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.test.tsx
@@ -1,0 +1,18 @@
+// Copyright 2023 Paion Data. All rights reserved.
+import { describe, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import DropDown from "./DropDown";
+describe("DropDown DOM test", () => {
+  test("DropDown", () => {
+    render(<DropDown buttonClassName={""} children={undefined} />);
+    expect(screen.getByRole("button")).toHaveProperty("disabled");
+  });
+});
+
+describe("DropDownItem DOM test", () => {
+  test("DropDownItem", () => {
+    render(<DropDown buttonClassName={""} children={undefined} />);
+    expect(screen.getByRole("button")).toHaveProperty("disabled");
+  });
+});

--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.tsx
@@ -220,7 +220,7 @@ export default function DropDown({
         onClick={() => setShowDropDown(!showDropDown)}
         ref={buttonRef}
       >
-        {buttonIconClassName && <span className={buttonIconClassName} />}
+        {buttonIconClassName && <span data-testid={"iconid"} className={buttonIconClassName} />}
         {buttonLabel && <span className="text dropdown-button-text">{buttonLabel}</span>}
         <i className="chevron-down" />
       </button>

--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.tsx
@@ -13,9 +13,12 @@ const DropDownContext = React.createContext<DropDownContextType | null>(null);
 const dropDownPadding = 4;
 
 /**
- * Single button in dropdown menu
+ * DropDownItem is a reuse wrapper for `button`
  *
- * @param param0
+ * @param children Children lets you manipulate and transform the JSX you received as the [children prop](https://react.dev/reference/react/Children).
+ * @param className Set the [class attribute](https://www.w3schools.com/jsref/prop_html_classname.asp) for an button element:
+ * @param onClick The [onclick](https://www.w3schools.com/jsref/event_onclick.asp) event occurs when the user clicks on an HTML element.
+ * @param title The [title attribute](https://www.w3schools.com/tags/att_global_title.asp) specifies extra information about an bubtton element.
  *
  * @returns single button
  */
@@ -54,9 +57,11 @@ export function DropDownItem({
 }
 
 /**
- * Render dropdown menu
+ * DropDownItems is a reuse wrapper for `DropDownItem`
  *
- * @param param0
+ * @param children Children lets you manipulate and transform the JSX you received as the [children prop](https://react.dev/reference/react/Children).
+ * @param dropDownRef A hook to pass your [ref](https://react.dev/learn/manipulating-the-dom-with-refs) as the ref attribute to the JSX tag for which you want to get the DOM node:
+ * @param onClose The regular [onClose](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/close_event) callback function that acts on the drop-down menu
  *
  * @returns dropdown menu
  */
@@ -133,9 +138,15 @@ function DropDownItems({
 }
 
 /**
- * Put the DOM nodes of the passed dropdowns into the provided document.body
+ * DropDown is a reuse wrapper for drop-down button and drop-down menu,
  *
- * @param param0
+ * @param disabled The disabled property of [button](https://www.w3schools.com/tags/tag_button.asp)
+ * @param buttonLabel the value of span
+ * @param buttonAriaLabel [Provides an accessible name for the button element](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+ * @param buttonClassName Provides an [classname](https://www.w3schools.com/jsref/prop_html_classname.asp) for the button element
+ * @param buttonIconClassName Provides an [classname](https://www.w3schools.com/jsref/prop_html_classname.asp) for the icon element
+ * @param children Children lets you manipulate and transform the JSX you received as the [children prop](https://react.dev/reference/react/Children).
+ * @param stopCloseOnClickSelf A state variable acts the [hook](https://www.w3schools.com/react/react_useeffect.asp) of dropdown component that enables continuous color selection
  *
  * @returns dropdown button and dropdown menu components
  */

--- a/packages/nexusgraph-editor/src/Lexical/ui/DropDown.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/DropDown.tsx
@@ -220,7 +220,7 @@ export default function DropDown({
         onClick={() => setShowDropDown(!showDropDown)}
         ref={buttonRef}
       >
-        {buttonIconClassName && <span data-testid={"iconid"} className={buttonIconClassName} />}
+        {buttonIconClassName && <span className={buttonIconClassName} />}
         {buttonLabel && <span className="text dropdown-button-text">{buttonLabel}</span>}
         <i className="chevron-down" />
       </button>


### PR DESCRIPTION
Changelog
---------

### Added
 - 给DropDown 组件添加文档
 - 给DropDown 组件编写测试
 - 测试点为：

> 1. 实例化一个 DropDown 组件，指定 disabled，断言渲染出来的 button 等于指定的 disabled
> 2. 实例化一个 DropDown 组件，指定 buttonAriaLabel，断言渲染出来的 button等于指定的 buttonAriaLabel
> 3. 实例化一个 DropDown 组件，指定 buttonIconClassName，断言渲染出来的 span等于指定的 buttonIconClassName
> 4. 实例化一个 DropDown 组件，指定 buttonLabel，断言渲染出来的 span 的文本等于 buttonLabel
> 5. 实例化一个 DropDown 组件，指定 buttonClassName，断言渲染出来的 button 等于指定的 buttonClassName
> 6. 实例化一个 DropDown 组件，mock onClick函数，断言渲染指定的点击事件
> 7. 实例化一个 DropDown 组件，指定 children，断言渲染出来的 DropDown的子元素 等于 children
> 8. 实例化一个 DropDown 组件，指定 stopCloseOnClickSelf，断言渲染出来,达到预期功能

 - 给DropDownItem 组件添加文档
 - 给DropDownItem 组件编写测试
 - 测试点为：

> 1. 实例化一个 DropDownItem 组件，指定 title，断言渲染出来的 button 等于指定的 title
> 2. 实例化一个 DropDownItem 组件，指定 className，断言渲染出来的 button 等于指定的 className
> 3. 实例化一个 DropDownItem 组件，mock onClick函数，断言渲染指定的点击事件
> 4. 实例化一个 DropDownItem 组件，指定 children，断言渲染出来的 DropDown的子元素 等于 children
### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [ ] Test
* [ ] Self-review
* [ ] Documentation
