### PR TITLE
Write ColorPicker document and color

### DIFF
--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
@@ -6,7 +6,21 @@ import "@testing-library/jest-dom";
 import ColorPicker from "./ColorPicker";
 
 describe("ColorPicker DOM test", () => {
-  test("Placeholder defaults to an empty string", () => {
-    render(<ColorPicker color={""} />);
+  test("ColorPicker displays specified color", () => {
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+    expect(screen.getByRole("textbox")).toHaveProperty("value", "#ffffff");
+  });
+
+  test("Mock onChange function and be called once", () => {
+    const onBgColorChange = jest.fn();
+    render(<ColorPicker color={"#ffffff"} onChange={onBgColorChange} />);
+    expect(onBgColorChange).toHaveBeenCalled;
   });
 });

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 Paion Data. All rights reserved.
 import { describe, expect } from "@jest/globals";
-import { fireEvent, getByRole, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
 import ColorPicker from "./ColorPicker";
@@ -25,8 +25,8 @@ describe("ColorPicker DOM test", () => {
   });
 });
 
-describe("Change the value of textinput to render the specified color",()=>{
-  beforeEach(()=>{
+describe("Change the value of textinput to render the specified color", () => {
+  beforeEach(() => {
     render(
       <ColorPicker
         color={"#ffffff"}
@@ -35,55 +35,271 @@ describe("Change the value of textinput to render the specified color",()=>{
         }}
       />
     );
-    fireEvent.change(screen.getByRole("textbox"), {target: {value: '#555555'}})
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "#555555" } });
   });
 
-  test("textinput and color-picker-color box render the correct color", () => {
-    expect(screen.getByRole("textbox").getAttribute('value')).toBe('#555555');
-    expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
-    expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe("background-color: rgb(85, 85, 85);");
-  });
-})
-
-describe("Click the basic color button to render the specified color",()=>{
-  beforeEach(()=>{
-    render(
-      <ColorPicker
-        color={"#ffffff"}
-        onChange={() => {
-          //do nothing.
-        }}
-      />
-    );
-    expect(screen.getAllByRole("button")).toHaveLength(16);
-    fireEvent.click(screen.getAllByRole("button")[2]);
-  });
-
-  test("Correctly render selected buttons", () => {
-    expect(screen.getAllByRole("button")[2].getAttribute("class")).toBe(" active");
-  });
-})
-
-describe("Move Wrapper on color-picker-saturation box to render the specified color",()=>{
-  beforeEach(()=>{
-    render(
-      <ColorPicker
-        color={"#ffffff"}
-        onChange={() => {
-          //do nothing.
-        }}
-      />
-    );
-    // var evt = document.getElementsByClassName('color-picker-saturation')[0];
-    // evt.clientX = 10;
-    // evt.clientY = 10;
-    // document.getElementById("link2").fireEvent("onmousemove", evt);
-    expect(document.getElementsByClassName('color-picker-saturation_cursor')).toHaveLength(1);
-    fireEvent.change(document.getElementsByClassName('color-picker-saturation_cursor')[0], {target: {style: "background-color: rgb(97, 93, 40); left: 126.5px; top: 92.7375px;"}})
+  test("textinput render the correct color text", () => {
+    expect(screen.getByRole("textbox").getAttribute("value")).toBe("#555555");
   });
 
   test("Color-picker-saturation box render the correct color and position", () => {
     expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
-    expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe("background-color: rgb(248, 231, 28); left: 189.8387096774194px; top: 4.117647058823536px;");
+    expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe(
+      "background-color: rgb(85, 85, 85); left: 0px; top: 100.00000000000001px;"
+    );
   });
-})
+
+  test("Color-picker-hue box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-hue_cursor").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-hue_cursor")[0].getAttribute("style")).toBe(
+      "background-color: rgb(255, 0, 0); left: 0px;"
+    );
+  });
+
+  test("Color-picker-color box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe(
+      "background-color: rgb(85, 85, 85);"
+    );
+  });
+});
+
+for (let i = 0; i < 16; i++) {
+  describe(`Click the basic color button to render the specified color ,the button ${i + 1}`, () => {
+    const rgbColor = [
+      "rgb(208, 2, 27)",
+      "rgb(245, 166, 35)",
+      "rgb(248, 231, 28)",
+      "rgb(139, 87, 42)",
+      "rgb(126, 211, 33)",
+      "rgb(65, 117, 5)",
+      "rgb(189, 16, 224)",
+      "rgb(144, 19, 254)",
+      "rgb(74, 144, 226)",
+      "rgb(80, 227, 194)",
+      "rgb(184, 233, 134)",
+      "rgb(0, 0, 0)",
+      "rgb(74, 74, 74)",
+      "rgb(155, 155, 155)",
+      "rgb(255, 255, 255)",
+      "rgb(143, 196, 221)",
+    ];
+
+    const rgbhue = [
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(0, 0, 0)",
+      "rgb(255, 0, 0)",
+      "rgb(255, 0, 0)",
+      "rgb(255, 0, 0)",
+      "rgb(255, 0, 0)",
+      "rgb(0, 0, 0)",
+    ];
+
+    const saturationLeft = [
+      "211.9423076923077px",
+      "183.42857142857142px",
+      "189.8387096774194px",
+      "149.33812949640287px",
+      "180.5308056872038px",
+      "204.85470085470087px",
+      "198.71428571428572px",
+      "197.99212598425194px",
+      "143.92920353982296px",
+      "138.58149779735686px",
+      "90.92703862660944px",
+      "0px",
+      "0px",
+      "0px",
+      "0px",
+      "75.52941176470588px",
+    ];
+
+    const saturationTop = [
+      "27.64705882352942px",
+      "5.88235294117647px",
+      "4.117647058823536px",
+      "68.23529411764706px",
+      "25.882352941176485px",
+      "81.17647058823529px",
+      "18.235294117647058px",
+      "0.588235294117645px",
+      "17.058823529411768px",
+      "16.470588235294123px",
+      "12.94117647058823px",
+      "150px",
+      "106.4705882352941px",
+      "58.82352941176471px",
+      "0px",
+      "19.999999999999993px",
+    ];
+
+    const hueLeft = [
+      "209.67152103559872px",
+      "22.24920634920635px",
+      "32.910606060606064px",
+      "16.546391752577325px",
+      "52.698501872659165px",
+      "52.22619047619048px",
+      "172.33173076923075px",
+      "161.6382978723404px",
+      "126.24122807017544px",
+      "98.99319727891155px",
+      "53.319865319865315px",
+      "0px",
+      "0px",
+      "0px",
+      "0px",
+      "118.43162393162393px",
+    ];
+
+    const colorText = [
+      "#d0021b",
+      "#f5a623",
+      "#f8e71c",
+      "#8b572a",
+      "#7ed321",
+      "#417505",
+      "#bd10e0",
+      "#9013fe",
+      "#4a90e2",
+      "#50e3c2",
+      "#b8e986",
+      "#000000",
+      "#4a4a4a",
+      "#9b9b9b",
+      "#ffffff",
+      "#8fc4dd",
+    ];
+
+    beforeEach(() => {
+      render(
+        <ColorPicker
+          color={"#ffffff"}
+          onChange={() => {
+            //do nothing.
+          }}
+        />
+      );
+      expect(screen.getAllByRole("button")).toHaveLength(16);
+      fireEvent.click(screen.getAllByRole("button")[i]);
+    });
+
+    test("Correctly render selected buttons", () => {
+      expect(screen.getAllByRole("button")[i].getAttribute("class")).toBe(" active");
+    });
+
+    test("textinput render the correct color text", () => {
+      expect(screen.getByRole("textbox").getAttribute("value")).toBe(colorText[i]);
+    });
+
+    test("Color-picker-saturation box render the correct color and position", () => {
+      expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
+      expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe(
+        `background-color: ${rgbColor[i]}; left: ${saturationLeft[i]}; top: ${saturationTop[i]};`
+      );
+    });
+
+    test("Color-picker-hue box render the correct color and position", () => {
+      expect(document.getElementsByClassName("color-picker-hue_cursor").length).toBe(1);
+      expect(document.getElementsByClassName("color-picker-hue_cursor")[0].getAttribute("style")).toBe(
+        `background-color: ${rgbhue[i]}; left: ${hueLeft[i]};`
+      );
+    });
+
+    test("Color-picker-color box render the correct color and position", () => {
+      expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
+      expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe(
+        `background-color: ${rgbColor[i]};`
+      );
+    });
+  });
+}
+
+describe("Change the positon of Color-picker-saturation boll to render the correct color", () => {
+  beforeEach(() => {
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+  });
+  const saturation = document.getElementsByClassName("color-picker-saturation")[0];
+  fireEvent.change(saturation, { target: { x: 98, y: 99 } });
+
+  test("textinput render the correct color text", () => {
+    expect(screen.getByRole("textbox").getAttribute("value")).toBe("#555555");
+  });
+
+  test("Color-picker-saturation box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe(
+      "background-color: rgb(85, 85, 85); left: 0px; top: 100.00000000000001px;"
+    );
+  });
+
+  test("Color-picker-hue box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-hue_cursor").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-hue_cursor")[0].getAttribute("style")).toBe(
+      "background-color: rgb(255, 0, 0); left: 0px;"
+    );
+  });
+
+  test("Color-picker-color box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe(
+      "background-color: rgb(85, 85, 85);"
+    );
+  });
+});
+
+describe("Change the positon of Color-picker-hue boll to render the correct color", () => {
+  beforeEach(() => {
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+  });
+  const saturation = document.getElementsByClassName("color-picker-saturation")[0];
+  fireEvent.change(saturation, { target: { x: 98, y: 99 } });
+
+  test("textinput render the correct color text", () => {
+    expect(screen.getByRole("textbox").getAttribute("value")).toBe("#555555");
+  });
+
+  test("Color-picker-saturation box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe(
+      "background-color: rgb(85, 85, 85); left: 0px; top: 100.00000000000001px;"
+    );
+  });
+
+  test("Color-picker-hue box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-hue_cursor").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-hue_cursor")[0].getAttribute("style")).toBe(
+      "background-color: rgb(255, 0, 0); left: 0px;"
+    );
+  });
+
+  test("Color-picker-color box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe(
+      "background-color: rgb(85, 85, 85);"
+    );
+  });
+});

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
@@ -64,165 +64,169 @@ describe("Change the value of textinput to render the specified color", () => {
   });
 });
 
-for (let i = 0; i < 16; i++) {
-  describe(`Click the basic color button to render the specified color ,the button ${i + 1}`, () => {
-    const rgbColor = [
-      "rgb(208, 2, 27)",
-      "rgb(245, 166, 35)",
-      "rgb(248, 231, 28)",
-      "rgb(139, 87, 42)",
-      "rgb(126, 211, 33)",
-      "rgb(65, 117, 5)",
-      "rgb(189, 16, 224)",
-      "rgb(144, 19, 254)",
-      "rgb(74, 144, 226)",
-      "rgb(80, 227, 194)",
-      "rgb(184, 233, 134)",
-      "rgb(0, 0, 0)",
-      "rgb(74, 74, 74)",
-      "rgb(155, 155, 155)",
-      "rgb(255, 255, 255)",
-      "rgb(143, 196, 221)",
-    ];
+describe(`Click the basic color button to render the specified color`, () => {
+  const rgbColor = [
+    "rgb(208, 2, 27)",
+    "rgb(245, 166, 35)",
+    "rgb(248, 231, 28)",
+    "rgb(139, 87, 42)",
+    "rgb(126, 211, 33)",
+    "rgb(65, 117, 5)",
+    "rgb(189, 16, 224)",
+    "rgb(144, 19, 254)",
+    "rgb(74, 144, 226)",
+    "rgb(80, 227, 194)",
+    "rgb(184, 233, 134)",
+    "rgb(0, 0, 0)",
+    "rgb(74, 74, 74)",
+    "rgb(155, 155, 155)",
+    "rgb(255, 255, 255)",
+    "rgb(143, 196, 221)",
+  ];
 
-    const rgbhue = [
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(0, 0, 0)",
-      "rgb(255, 0, 0)",
-      "rgb(255, 0, 0)",
-      "rgb(255, 0, 0)",
-      "rgb(255, 0, 0)",
-      "rgb(0, 0, 0)",
-    ];
+  const rgbhue = [
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(0, 0, 0)",
+    "rgb(255, 0, 0)",
+    "rgb(255, 0, 0)",
+    "rgb(255, 0, 0)",
+    "rgb(255, 0, 0)",
+    "rgb(0, 0, 0)",
+  ];
 
-    const saturationLeft = [
-      "211.9423076923077px",
-      "183.42857142857142px",
-      "189.8387096774194px",
-      "149.33812949640287px",
-      "180.5308056872038px",
-      "204.85470085470087px",
-      "198.71428571428572px",
-      "197.99212598425194px",
-      "143.92920353982296px",
-      "138.58149779735686px",
-      "90.92703862660944px",
-      "0px",
-      "0px",
-      "0px",
-      "0px",
-      "75.52941176470588px",
-    ];
+  const saturationLeft = [
+    "211.9423076923077px",
+    "183.42857142857142px",
+    "189.8387096774194px",
+    "149.33812949640287px",
+    "180.5308056872038px",
+    "204.85470085470087px",
+    "198.71428571428572px",
+    "197.99212598425194px",
+    "143.92920353982296px",
+    "138.58149779735686px",
+    "90.92703862660944px",
+    "0px",
+    "0px",
+    "0px",
+    "0px",
+    "75.52941176470588px",
+  ];
 
-    const saturationTop = [
-      "27.64705882352942px",
-      "5.88235294117647px",
-      "4.117647058823536px",
-      "68.23529411764706px",
-      "25.882352941176485px",
-      "81.17647058823529px",
-      "18.235294117647058px",
-      "0.588235294117645px",
-      "17.058823529411768px",
-      "16.470588235294123px",
-      "12.94117647058823px",
-      "150px",
-      "106.4705882352941px",
-      "58.82352941176471px",
-      "0px",
-      "19.999999999999993px",
-    ];
+  const saturationTop = [
+    "27.64705882352942px",
+    "5.88235294117647px",
+    "4.117647058823536px",
+    "68.23529411764706px",
+    "25.882352941176485px",
+    "81.17647058823529px",
+    "18.235294117647058px",
+    "0.588235294117645px",
+    "17.058823529411768px",
+    "16.470588235294123px",
+    "12.94117647058823px",
+    "150px",
+    "106.4705882352941px",
+    "58.82352941176471px",
+    "0px",
+    "19.999999999999993px",
+  ];
 
-    const hueLeft = [
-      "209.67152103559872px",
-      "22.24920634920635px",
-      "32.910606060606064px",
-      "16.546391752577325px",
-      "52.698501872659165px",
-      "52.22619047619048px",
-      "172.33173076923075px",
-      "161.6382978723404px",
-      "126.24122807017544px",
-      "98.99319727891155px",
-      "53.319865319865315px",
-      "0px",
-      "0px",
-      "0px",
-      "0px",
-      "118.43162393162393px",
-    ];
+  const hueLeft = [
+    "209.67152103559872px",
+    "22.24920634920635px",
+    "32.910606060606064px",
+    "16.546391752577325px",
+    "52.698501872659165px",
+    "52.22619047619048px",
+    "172.33173076923075px",
+    "161.6382978723404px",
+    "126.24122807017544px",
+    "98.99319727891155px",
+    "53.319865319865315px",
+    "0px",
+    "0px",
+    "0px",
+    "0px",
+    "118.43162393162393px",
+  ];
 
-    const colorText = [
-      "#d0021b",
-      "#f5a623",
-      "#f8e71c",
-      "#8b572a",
-      "#7ed321",
-      "#417505",
-      "#bd10e0",
-      "#9013fe",
-      "#4a90e2",
-      "#50e3c2",
-      "#b8e986",
-      "#000000",
-      "#4a4a4a",
-      "#9b9b9b",
-      "#ffffff",
-      "#8fc4dd",
-    ];
-
-    beforeEach(() => {
-      render(
-        <ColorPicker
-          color={"#ffffff"}
-          onChange={() => {
-            //do nothing.
-          }}
-        />
-      );
-      expect(screen.getAllByRole("button")).toHaveLength(16);
-      fireEvent.click(screen.getAllByRole("button")[i]);
-    });
-
-    test("Correctly render selected buttons", () => {
-      expect(screen.getAllByRole("button")[i].getAttribute("class")).toBe(" active");
-    });
-
-    test("textinput render the correct color text", () => {
-      expect(screen.getByRole("textbox").getAttribute("value")).toBe(colorText[i]);
-    });
-
-    test("Color-picker-saturation box render the correct color and position", () => {
-      expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
-      expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe(
-        `background-color: ${rgbColor[i]}; left: ${saturationLeft[i]}; top: ${saturationTop[i]};`
-      );
-    });
-
-    test("Color-picker-hue box render the correct color and position", () => {
-      expect(document.getElementsByClassName("color-picker-hue_cursor").length).toBe(1);
-      expect(document.getElementsByClassName("color-picker-hue_cursor")[0].getAttribute("style")).toBe(
-        `background-color: ${rgbhue[i]}; left: ${hueLeft[i]};`
-      );
-    });
-
-    test("Color-picker-color box render the correct color and position", () => {
-      expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
-      expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe(
-        `background-color: ${rgbColor[i]};`
-      );
-    });
+  const colorText = [
+    "#d0021b",
+    "#f5a623",
+    "#f8e71c",
+    "#8b572a",
+    "#7ed321",
+    "#417505",
+    "#bd10e0",
+    "#9013fe",
+    "#4a90e2",
+    "#50e3c2",
+    "#b8e986",
+    "#000000",
+    "#4a4a4a",
+    "#9b9b9b",
+    "#ffffff",
+    "#8fc4dd",
+  ];
+  beforeEach(() => {
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(16);
   });
-}
+  for (let i = 0; i < 16; i++) {
+    describe(`click the basic color button ${i + 1}`, () => {
+      test("Correctly render selected buttons", () => {
+        fireEvent.click(screen.getAllByRole("button")[i]);
+        expect(screen.getAllByRole("button")[i].getAttribute("class")).toBe(" active");
+      });
+
+      test("textinput render the correct color text", () => {
+        fireEvent.click(screen.getAllByRole("button")[i]);
+        expect(screen.getByRole("textbox").getAttribute("value")).toBe(colorText[i]);
+      });
+
+      test("Color-picker-saturation box render the correct color and position", () => {
+        fireEvent.click(screen.getAllByRole("button")[i]);
+        expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
+        expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe(
+          `background-color: ${rgbColor[i]}; left: ${saturationLeft[i]}; top: ${saturationTop[i]};`
+        );
+      });
+
+      test("Color-picker-hue box render the correct color and position", () => {
+        fireEvent.click(screen.getAllByRole("button")[i]);
+        expect(document.getElementsByClassName("color-picker-hue_cursor").length).toBe(1);
+        expect(document.getElementsByClassName("color-picker-hue_cursor")[0].getAttribute("style")).toBe(
+          `background-color: ${rgbhue[i]}; left: ${hueLeft[i]};`
+        );
+      });
+
+      test("Color-picker-color box render the correct color and position", () => {
+        fireEvent.click(screen.getAllByRole("button")[i]);
+        expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
+        expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe(
+          `background-color: ${rgbColor[i]};`
+        );
+      });
+    });
+  }
+});
 
 describe("Change the positon of Color-picker-saturation boll to render the correct color", () => {
   beforeEach(() => {

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
@@ -1,0 +1,12 @@
+// Copyright 2023 Paion Data. All rights reserved.
+import { describe, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import "@testing-library/jest-dom";
+import ColorPicker from "./ColorPicker";
+
+describe("ColorPicker DOM test", () => {
+  test("Placeholder defaults to an empty string", () => {
+    render(<ColorPicker color={""} />);
+  });
+});

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 Paion Data. All rights reserved.
 import { describe, expect } from "@jest/globals";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
 import ColorPicker from "./ColorPicker";
@@ -271,20 +271,29 @@ describe("Change the positon of Color-picker-saturation boll to render the corre
 describe("Change the positon of Color-picker-hue boll to render the correct color", () => {
   beforeEach(() => {
     render(
-      <ColorPicker
-        color={"#ffffff"}
-        onChange={() => {
-          //do nothing.
-        }}
-      />
-    );
-  });
-  const saturation = document.getElementsByClassName("color-picker-saturation")[0];
-  fireEvent.change(saturation, { target: { x: 98, y: 99 } });
+        <ColorPicker
+          color={"#ffffff"}
+          onChange={() => {
+            //do nothing.
+          }}
+        />
+  );
+    const evt = new MouseEvent("mousedown", {
+      view: window,
+      bubbles: true,
+      cancelable: true,
+      clientX:50,
+      clientY:50,
+      button:0
+    });
 
-  test("textinput render the correct color text", () => {
-    expect(screen.getByRole("textbox").getAttribute("value")).toBe("#555555");
+    act(() => {
+      document.getElementsByClassName('color-picker-saturation')[0].dispatchEvent(evt); 
+    });
   });
+  test("textinput render the correct color text", () => {
+    expect(screen.getByRole("textbox").getAttribute("value")).toBe(1);
+  })
 
   test("Color-picker-saturation box render the correct color and position", () => {
     expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.test.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 Paion Data. All rights reserved.
 import { describe, expect } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, getByRole, render, screen } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
 import ColorPicker from "./ColorPicker";
@@ -24,3 +24,66 @@ describe("ColorPicker DOM test", () => {
     expect(onBgColorChange).toHaveBeenCalled;
   });
 });
+
+describe("Change the value of textinput to render the specified color",()=>{
+  beforeEach(()=>{
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {target: {value: '#555555'}})
+  });
+
+  test("textinput and color-picker-color box render the correct color", () => {
+    expect(screen.getByRole("textbox").getAttribute('value')).toBe('#555555');
+    expect(document.getElementsByClassName("color-picker-color").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-color")[0].getAttribute("style")).toBe("background-color: rgb(85, 85, 85);");
+  });
+})
+
+describe("Click the basic color button to render the specified color",()=>{
+  beforeEach(()=>{
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(16);
+    fireEvent.click(screen.getAllByRole("button")[2]);
+  });
+
+  test("Correctly render selected buttons", () => {
+    expect(screen.getAllByRole("button")[2].getAttribute("class")).toBe(" active");
+  });
+})
+
+describe("Move Wrapper on color-picker-saturation box to render the specified color",()=>{
+  beforeEach(()=>{
+    render(
+      <ColorPicker
+        color={"#ffffff"}
+        onChange={() => {
+          //do nothing.
+        }}
+      />
+    );
+    // var evt = document.getElementsByClassName('color-picker-saturation')[0];
+    // evt.clientX = 10;
+    // evt.clientY = 10;
+    // document.getElementById("link2").fireEvent("onmousemove", evt);
+    expect(document.getElementsByClassName('color-picker-saturation_cursor')).toHaveLength(1);
+    fireEvent.change(document.getElementsByClassName('color-picker-saturation_cursor')[0], {target: {style: "background-color: rgb(97, 93, 40); left: 126.5px; top: 92.7375px;"}})
+  });
+
+  test("Color-picker-saturation box render the correct color and position", () => {
+    expect(document.getElementsByClassName("color-picker-saturation_cursor").length).toBe(1);
+    expect(document.getElementsByClassName("color-picker-saturation_cursor")[0].getAttribute("style")).toBe("background-color: rgb(248, 231, 28); left: 189.8387096774194px; top: 4.117647058823536px;");
+  });
+})

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.tsx
@@ -31,11 +31,12 @@ const WIDTH = 214;
 const HEIGHT = 150;
 
 /**
- * Render basic color ,hux ,saturation and selected color components
+ * 'DropdownColorPicker' is a wrapper for' TextInput 'and' MoveWrapper ', used in the editor for color selection box
  *
- * @param param0
+ * @param color A color [state](https://react.dev/reference/react/useState) variable declared in the ToolbarPlugin component. Used to update color values
+ * @param onChange onChange The regular [onChange](https://www.w3schools.com/jsref/event_onchange.asp) callback function that acts on the color of selection
  *
- * @returns Basic color ,hux ,saturation and selected color div components
+ * @returns  The JSX of color selection box
  */
 export default function ColorPicker({ color, onChange }: Readonly<ColorPickerProps>): JSX.Element {
   const [selfColor, setSelfColor] = useState(transformColor("hex", color));
@@ -149,18 +150,33 @@ export interface Position {
 }
 
 interface MoveWrapperProps {
+  /**
+   * Set the [class attribute](https://www.w3schools.com/jsref/prop_html_classname.asp) for an div element:
+   */
   className?: string;
+
+  /**
+   * The <style>[https://www.w3schools.com/tags/tag_style.asp] tag is used to define style information (CSS) for a document.
+   */
   style?: React.CSSProperties;
+
+  /**
+   * onChange The regular [onChange](https://www.w3schools.com/jsref/event_onchange.asp) callback function that acts on the position of a small round ball for color selection
+   */
   onChange: (position: Position) => void;
+
+  /**
+   * children lets you manipulate and transform the JSX you received as the [children prop](https://react.dev/reference/react/Children).
+   */
   children: JSX.Element;
 }
 
 /**
- * Render saturation
+ * 'DropdownColorPicker' is a wrapper for move a small round ball for color selection
  *
- * @param param0
+ * @param MoveWrapperProps
  *
- * @returns saturation div
+ * @returns A JSX of a small round ball for color selection
  */
 function MoveWrapper({ className, style, onChange, children }: MoveWrapperProps) {
   const divRef = useRef<HTMLDivElement>(null);
@@ -225,11 +241,11 @@ interface Color {
 }
 
 /**
- * Convert the value to hexadecimal
+ * A convert function for convert the value to [hex](https://www.w3schools.com/colors/colors_hexadecimal.asp) used to represent color
  *
  * @param value
  *
- * @returns hex
+ * @returns The value of color hex
  */
 export function toHex(value: string): string {
   if (!value.startsWith("#")) {
@@ -257,9 +273,9 @@ export function toHex(value: string): string {
 }
 
 /**
- * Convert hex to rgb
+ * A convert function for convert hex to [rgb](https://www.w3schools.com/colors/colors_rgb.asp)
  *
- * @param hex
+ * @param hex string ，the value of color hex
  *
  * @returns r , g , b
  */
@@ -279,9 +295,11 @@ function hex2rgb(hex: string): RGB {
 }
 
 /**
- * Convert rgb to hsv
+ * A convert function for convert rgb to [hsv](https://en.wikipedia.org/wiki/HSL_and_HSV)
  *
- * @param {r , g , b}
+ * @param r red
+ * @param g green
+ * @param b bule
  *
  * @returns h , s ,v
  */
@@ -301,9 +319,11 @@ function rgb2hsv({ r, g, b }: RGB): HSV {
 }
 
 /**
- * Convert hsv to rgb form
+ * A convert function for convert hsv to [rgb](https://www.w3schools.com/colors/colors_rgb.asp)
  *
- * @param {h , s , v}
+ * @param h Hue
+ * @param s saturation
+ * @param v lightness
  *
  * @returns b , g , r
  */
@@ -326,9 +346,11 @@ function hsv2rgb({ h, s, v }: HSV): RGB {
 }
 
 /**
- * Convert rgb to hex form
+ * A convert function for convert rgb to hex
  *
- * @param {r , g , b}
+ * @param r red
+ * @param g green
+ * @param b bule
  *
  * @returns hex
  */
@@ -337,10 +359,10 @@ function rgb2hex({ b, g, r }: RGB): string {
 }
 
 /**
- * Realize arbitrary conversion between rgb, hsv, hex
+ * A convert function for implement arbitrary conversion between rgb, hsv, hex
  *
- * @param format
- * @param color
+ * @param format string
+ * @param color string
  *
  * @returns hex , hsv , rgb
  */

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.tsx
@@ -225,25 +225,58 @@ function clamp(value: number, max: number, min: number) {
 }
 
 interface RGB {
+  /**
+   * The [blue](https://www.w3schools.com/colors/colors_rgb.asp) parameter in rgb code color system
+   */
   b: number;
+
+  /**
+   * The [green](https://www.w3schools.com/colors/colors_rgb.asp) parameter in rgb code color system
+   */
   g: number;
+
+  /**
+   * The [red](https://www.w3schools.com/colors/colors_rgb.asp) parameter in rgb code color system
+   */
   r: number;
 }
 interface HSV {
+  /**
+   * The [hue](https://en.wikipedia.org/wiki/HSL_and_HSV) parameter in hsv code color system
+   */
   h: number;
+
+  /**
+   * The [saturation](https://en.wikipedia.org/wiki/HSL_and_HSV) parameter in hsv code color system
+   */
   s: number;
+
+  /**
+   * The [value](https://en.wikipedia.org/wiki/HSL_and_HSV) parameter in hsv code color system
+   */
   v: number;
 }
 interface Color {
+  /**
+   * The value of hex color
+   */
   hex: string;
+
+  /**
+   * The value of hsv color
+   */
   hsv: HSV;
+  
+  /**
+   * The value of rgb color
+   */
   rgb: RGB;
 }
 
 /**
  * A convert function for convert the value to [hex](https://www.w3schools.com/colors/colors_hexadecimal.asp) used to represent color
  *
- * @param value
+ * @param value string
  *
  * @returns The value of color hex
  */
@@ -297,9 +330,7 @@ function hex2rgb(hex: string): RGB {
 /**
  * A convert function for convert rgb to [hsv](https://en.wikipedia.org/wiki/HSL_and_HSV)
  *
- * @param r red
- * @param g green
- * @param b bule
+ * @param RGB
  *
  * @returns h , s ,v
  */
@@ -321,9 +352,7 @@ function rgb2hsv({ r, g, b }: RGB): HSV {
 /**
  * A convert function for convert hsv to [rgb](https://www.w3schools.com/colors/colors_rgb.asp)
  *
- * @param h Hue
- * @param s saturation
- * @param v lightness
+ * @param HSV
  *
  * @returns b , g , r
  */
@@ -348,9 +377,7 @@ function hsv2rgb({ h, s, v }: HSV): RGB {
 /**
  * A convert function for convert rgb to hex
  *
- * @param r red
- * @param g green
- * @param b bule
+ * @param RGB
  *
  * @returns hex
  */
@@ -361,8 +388,7 @@ function rgb2hex({ b, g, r }: RGB): string {
 /**
  * A convert function for implement arbitrary conversion between rgb, hsv, hex
  *
- * @param format string
- * @param color string
+ * @param Color
  *
  * @returns hex , hsv , rgb
  */

--- a/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/ui/ColorPicker.tsx
@@ -266,7 +266,7 @@ interface Color {
    * The value of hsv color
    */
   hsv: HSV;
-  
+
   /**
    * The value of rgb color
    */


### PR DESCRIPTION
Changelog
---------

### Added

### Changed
 - 给ColorPicker 组件添加文档
 - 给ColorPicker 组件编写测试
 - 测试点为：

> 1. 实例化一个 ColorPicker 组件，指定 color，断言渲染出指定的 color
> 2. 实例化一个 ColorPicker 组件，mock onChange函数，断言渲染指定的事件
> 3. 实例化一个 ColorPicker 组件，指定 textInput color，Color-picker-saturation, Color-picker-hue, Color-picker-color断言渲染出正确的 color
> 4. 实例化一个 ColorPicker 组件，点击basic color button，textInput ,Color-picker-saturation, Color-picker-hue, Color-picker-color断言渲染出正确的 color
> 5. 实例化一个 ColorPicker 组件，指定 点击saturation 框中的指定位置，textInput ,Color-picker-saturation, Color-picker-hue, Color-picker-color断言渲染出正确的 color
> 6. 实例化一个 ColorPicker 组件，指定 点击hue 框中的指定位置，textInput ,Color-picker-saturation, Color-picker-hue, Color-picker-color断言渲染出正确的 color

有待解决问题：
 - 测试4: [测试断言出的hue-rgb的值与在浏览器上的hue-rgb的值不一致](https://stackoverflow.com/questions/39208559/browsers-automatically-evaluate-hex-or-hsl-colors-to-rgb-when-setting-via-elemen)
 - 测试5: [无法触发组件中的onMouseDown函数，以至于无法进行后续断言](https://jestjs.io/docs/next/tutorial-react)
 - 测试6: 无法触发组件中的onMouseDown函数，以至于无法进行后续断言
 - 测试查重不通过

>[如何对非导出函数进行单元测试？]( https://stackoverflow.com/questions/54116070/how-can-i-unit-test-non-exported-functions)
>[]()

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [ ] Test
* [ ] Self-review
* [ ] Documentation
