### PR TITLE
Modify DevTools failed to load SourceMap

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -84,7 +84,7 @@ jobs:
 
   e2e-tests:
     needs: [yaml-lint, markdown-lint, markdown-link-check, code-style]
-    uses: paion-data/github-actions-workflows/.github/workflows/e2e-tests.yml@master
+    uses: paion-data/github-actions-workflows/.github/workflows/cypress-e2e-tests.yml@master
 
   release:
     name: Publish NPM Packages

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -3,7 +3,6 @@ const path = require("path");
 const dotenv = require("dotenv");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const { SourceMapDevToolPlugin } = require("webpack");
 
 const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || "10000");
 
@@ -24,6 +23,7 @@ module.exports = function (webpackEnv) {
       path: path.resolve(__dirname, "../../dist"),
       filename: isProdEnvironment ? "static/js/[name].[contenthash:8].js" : "static/js/bundle.js",
     },
+    devtool: "source-map",
     module: {
       rules: [
         {
@@ -65,9 +65,6 @@ module.exports = function (webpackEnv) {
       ],
     },
     plugins: [
-      new SourceMapDevToolPlugin({
-        filename: "[file].map",
-      }),
       new webpack.DefinePlugin({ "process.env": envKeys }),
       new webpack.HotModuleReplacementPlugin(),
       // Generates an `index.html` file with the <script> injected.

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = function (webpackEnv) {
       path: path.resolve(__dirname, "../../dist"),
       filename: isProdEnvironment ? "static/js/[name].[contenthash:8].js" : "static/js/bundle.js",
     },
-    devtool: "source-map",
     module: {
       rules: [
         {
@@ -62,8 +61,13 @@ module.exports = function (webpackEnv) {
             },
           },
         },
+        {
+          test: /\.(m?js|ts)$/,
+          use: ["source-map-loader"],
+        },
       ],
     },
+    ignoreWarnings: [/Failed to parse source map/],
     plugins: [
       new webpack.DefinePlugin({ "process.env": envKeys }),
       new webpack.HotModuleReplacementPlugin(),

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 const dotenv = require("dotenv");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { SourceMapDevToolPlugin } = require("webpack");
 
 const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || "10000");
 
@@ -64,6 +65,9 @@ module.exports = function (webpackEnv) {
       ],
     },
     plugins: [
+      new SourceMapDevToolPlugin({
+        filename: "[file].map",
+      }),
       new webpack.DefinePlugin({ "process.env": envKeys }),
       new webpack.HotModuleReplacementPlugin(),
       // Generates an `index.html` file with the <script> injected.

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "prettier-plugin-organize-imports": "^3.2.3",
     "react-router-dom": "^6.8.1",
     "react-test-renderer": "^18.2.0",
+    "source-map-loader": "^1.0.0",
     "style-loader": "^3.3.1",
     "svg-url-loader": "^8.0.0",
     "ts-jest": "^27.1.4",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "prettier-plugin-organize-imports": "^3.2.3",
     "react-router-dom": "^6.8.1",
     "react-test-renderer": "^18.2.0",
-    "source-map-loader": "^1.0.0",
     "style-loader": "^3.3.1",
     "svg-url-loader": "^8.0.0",
     "ts-jest": "^27.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,7 +2495,6 @@ __metadata:
     react-router-dom: ^6.8.1
     react-test-renderer: ^18.2.0
     redux: ^4.2.1
-    source-map-loader: ^1.0.0
     style-loader: ^3.3.1
     styled-components: ^5.3.9
     svg-url-loader: ^8.0.0
@@ -11688,22 +11687,6 @@ __metadata:
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c
-  languageName: node
-  linkType: hard
-
-"source-map-loader@npm:^1.0.0":
-  version: 1.1.3
-  resolution: "source-map-loader@npm:1.1.3"
-  dependencies:
-    abab: ^2.0.5
-    iconv-lite: ^0.6.2
-    loader-utils: ^2.0.0
-    schema-utils: ^3.0.0
-    source-map: ^0.6.1
-    whatwg-mimetype: ^2.3.0
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: 0ca16a1458f206e12925f242ce52913b5f35de657d2ec17fd60ab3de7fa85b72b6707951b7a18899bdf05679d679a8b9edeb660c557aafa66453886d6907e3ec
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,6 +2495,7 @@ __metadata:
     react-router-dom: ^6.8.1
     react-test-renderer: ^18.2.0
     redux: ^4.2.1
+    source-map-loader: ^1.0.0
     style-loader: ^3.3.1
     styled-components: ^5.3.9
     svg-url-loader: ^8.0.0
@@ -11687,6 +11688,22 @@ __metadata:
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c
+  languageName: node
+  linkType: hard
+
+"source-map-loader@npm:^1.0.0":
+  version: 1.1.3
+  resolution: "source-map-loader@npm:1.1.3"
+  dependencies:
+    abab: ^2.0.5
+    iconv-lite: ^0.6.2
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
+    source-map: ^0.6.1
+    whatwg-mimetype: ^2.3.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 0ca16a1458f206e12925f242ce52913b5f35de657d2ec17fd60ab3de7fa85b72b6707951b7a18899bdf05679d679a8b9edeb660c557aafa66453886d6907e3ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed
**调试错误**：[DevTools failed to load SourceMap for webpack:///node_modules//....js.map HTTP error: status code 404, 
                          net::ERR_UNKNOWN_URL_SCHEME](https://stackoverflow.com/questions/61767538/devtools-failed-to-load-sourcemap-for-webpack-node-modules-js-map-http-e)

**原因**：之前采用的是默认源映射，[webpack 4 或更高版本以及该mode选项，该工具将在development模式下自动为您生成源映射](https://survivejs.com/webpack/building/source-maps/)

**解决方案**：使用source-map-loader将源映射处理为 webpack 包，让浏览器不会误解源映射数据

**调试错误**：[After Upgrading to CRA 5.0 getting a lot of: Failed to parse source map from](https://github.com/facebook/create-react-app/discussions/11767)

**原因**：webpack 5.x本身原因，一些第三方依赖会造成这种情况，[webpack 官方pull requests修复中]（https://github.com/facebook/create-react-app/pull/11752）

**解决方案**：使用webpack官方文档中的ignoreWarnings，告诉 webpack 忽略特定警告。

### Security

Checklist
---------

* [ ] Test
* [ ] Self-review
* [ ] Documentation
