### PR TITLE
Change for editor content type

### DIFF
--- a/packages/nexusgraph-app/src/ReduxHook.tsx
+++ b/packages/nexusgraph-app/src/ReduxHook.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { AstraiosClient } from "../../nexusgraph-astraios";
 import { NaturalLanguageProcessor } from "../../nexusgraph-nlp";
 import { GlobalState, NoteState, UPDATE_NLPDATA } from "../../nexusgraph-redux";
-import { selectNote } from "../../nexusgraph-redux/src/note/noteDuck";
+import { initialEditorContent, selectNote } from "../../nexusgraph-redux/src/note/noteDuck";
 import { container, TYPES } from "../inversify.config";
 
 export default function useReduxHook() {
@@ -27,7 +27,7 @@ export default function useReduxHook() {
         //   }
         // });
 
-        if (noteState && noteState.editorContent && JSON.stringify(noteState.editorContent) !== "{}") {
+        if (noteState && noteState.editorContent != initialEditorContent) {
           remoteNaturalLanguageProcessor.entityExtraction(noteState.editorContent).then((NlpState) => {
             dispatch({ type: UPDATE_NLPDATA, payload: NlpState });
           });

--- a/packages/nexusgraph-astraios/src/JsonApiAstraiosClient.ts
+++ b/packages/nexusgraph-astraios/src/JsonApiAstraiosClient.ts
@@ -72,7 +72,7 @@ export class JsonApiAstraiosClient implements AstraiosClient {
       id: note.id,
       attributes: {
         graph: note.graph,
-        editorContent: note.editorContent,
+        editorContent: JSON.stringify(note.editorContent),
       },
     });
   }

--- a/packages/nexusgraph-editor/src/Lexical/plugins/NexusgraphOnChangePlugin.tsx
+++ b/packages/nexusgraph-editor/src/Lexical/plugins/NexusgraphOnChangePlugin.tsx
@@ -27,7 +27,7 @@ export default function NexusgraphOnChangePlugin(): null {
 
   useEffect(() => {
     return editor.registerTextContentListener(() => {
-      dispatch({ type: UPDATE_NOTE_EDITOR_CONTENT, payload: JSON.stringify(editor.getEditorState()) });
+      dispatch({ type: UPDATE_NOTE_EDITOR_CONTENT, payload: editor.getEditorState() });
     });
   }, []);
 

--- a/packages/nexusgraph-nlp/src/processor/RemoteNaturalLanguageProcessor.ts
+++ b/packages/nexusgraph-nlp/src/processor/RemoteNaturalLanguageProcessor.ts
@@ -11,9 +11,9 @@ import { NaturalLanguageProcessor } from "./NaturalLanguageProcessor";
  */
 @injectable()
 export class RemoteNaturalLanguageProcessor implements NaturalLanguageProcessor {
-  public entityExtraction(editorContent: string): Promise<NlpState> {
+  public entityExtraction(editorContent: object): Promise<NlpState> {
     const parser = new EditorContentParser();
-    const jsonObject = JSON.parse(editorContent);
+    const jsonObject = JSON.parse(JSON.stringify(editorContent));
     const editorLines = parser.parse(jsonObject);
 
     return this.remoteEntityExtration(editorLines);

--- a/packages/nexusgraph-nlp/src/processor/RemoteNaturalLanguageProcessor.ts
+++ b/packages/nexusgraph-nlp/src/processor/RemoteNaturalLanguageProcessor.ts
@@ -15,7 +15,7 @@ export class RemoteNaturalLanguageProcessor implements NaturalLanguageProcessor 
     const parser = new EditorContentParser();
     const jsonObject = JSON.parse(JSON.stringify(editorContent));
     const editorLines = parser.parse(jsonObject);
-    
+
     return this.remoteEntityExtration(editorLines);
   }
 

--- a/packages/nexusgraph-nlp/src/processor/RemoteNaturalLanguageProcessor.ts
+++ b/packages/nexusgraph-nlp/src/processor/RemoteNaturalLanguageProcessor.ts
@@ -15,7 +15,7 @@ export class RemoteNaturalLanguageProcessor implements NaturalLanguageProcessor 
     const parser = new EditorContentParser();
     const jsonObject = JSON.parse(JSON.stringify(editorContent));
     const editorLines = parser.parse(jsonObject);
-
+    
     return this.remoteEntityExtration(editorLines);
   }
 

--- a/packages/nexusgraph-redux/src/note/noteDuck.ts
+++ b/packages/nexusgraph-redux/src/note/noteDuck.ts
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { GlobalState } from "../globalState";
 import { CREATE_NEW_NOTE, NoteState, UPDATE_NOTE_EDITOR_CONTENT, UPDATE_NOTE_GRAPH, UPDATE_NOTE_ID } from "./noteTypes";
 
-const initialEditorContent: object = {
+export const initialEditorContent: object = {
   root: {
     children: [
       {
@@ -30,6 +30,8 @@ const initialState: NoteState = {
 };
 
 export function selectNote() {
+  console.log(useSelector((state: GlobalState) => JSON.stringify(state.note.editorContent)));
+  
   return useSelector((state: GlobalState) => state.note);
 }
 

--- a/packages/nexusgraph-redux/src/note/noteDuck.ts
+++ b/packages/nexusgraph-redux/src/note/noteDuck.ts
@@ -30,8 +30,6 @@ const initialState: NoteState = {
 };
 
 export function selectNote() {
-  console.log(useSelector((state: GlobalState) => JSON.stringify(state.note.editorContent)));
-  
   return useSelector((state: GlobalState) => state.note);
 }
 

--- a/packages/nexusgraph-redux/src/note/noteDuck.ts
+++ b/packages/nexusgraph-redux/src/note/noteDuck.ts
@@ -1,18 +1,31 @@
 // Copyright 2023 Paion Data. All rights reserved.
 import { useSelector } from "react-redux";
 import { GlobalState } from "../globalState";
-import {
-  CREATE_NEW_NOTE,
-  NoteAction,
-  NoteState,
-  UPDATE_NOTE_EDITOR_CONTENT,
-  UPDATE_NOTE_GRAPH,
-  UPDATE_NOTE_ID,
-} from "./noteTypes";
+import { CREATE_NEW_NOTE, NoteState, UPDATE_NOTE_EDITOR_CONTENT, UPDATE_NOTE_GRAPH, UPDATE_NOTE_ID } from "./noteTypes";
+
+const initialEditorContent: object = {
+  root: {
+    children: [
+      {
+        children: [],
+        direction: null,
+        format: "",
+        indent: 0,
+        type: "paragraph",
+        version: 1,
+      },
+    ],
+    direction: null,
+    format: "",
+    indent: 0,
+    type: "root",
+    version: 1,
+  },
+};
 
 const initialState: NoteState = {
   id: "",
-  editorContent: "",
+  editorContent: initialEditorContent,
   graph: "",
 };
 
@@ -20,7 +33,7 @@ export function selectNote() {
   return useSelector((state: GlobalState) => state.note);
 }
 
-export default function noteReducer(state = initialState, action: NoteAction): NoteState {
+export default function noteReducer(state = initialState, action: any): NoteState {
   switch (action.type) {
     case UPDATE_NOTE_GRAPH:
       return {

--- a/packages/nexusgraph-redux/src/note/noteTypes.ts
+++ b/packages/nexusgraph-redux/src/note/noteTypes.ts
@@ -7,7 +7,7 @@ export const CREATE_NEW_NOTE = NOTE_STATE + "/CREATE_NEW_NOTE";
 
 export interface NoteState {
   id: string;
-  editorContent: string;
+  editorContent: object;
   graph: string;
 }
 


### PR DESCRIPTION
Changelog
---------

### Added

### Changed
- Change for editor content type in `noteDuck`. In addition, some related variable types are temporarily modified, such as `NoteAction => any`, `editorContent => object`, which will be improved in the subsequent pull request
- In `ReduxHook`, the presence of editorContent sends a request to the background, temporarily changing to `editorContent! = initialEditorContent` to send the request
### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [ ] Test
* [ ] Self-review
* [ ] Documentation
