### PR TITLE
Change for initial id state in noteDuck

### DIFF
--- a/packages/nexusgraph-app/src/ReduxHook.tsx
+++ b/packages/nexusgraph-app/src/ReduxHook.tsx
@@ -22,9 +22,7 @@ export default function useReduxHook() {
     const update = () => {
       if (noteState) {
         // astraiosClient.saveOrUpdate(noteState, accessToken).then((response) => {
-        //   if (response.id) {
         //     dispatch({ type: UPDATE_NOTE_ID, payload: response.id });
-        //   }
         // });
 
         if (noteState && noteState.editorContent != initialEditorContent) {

--- a/packages/nexusgraph-astraios/src/JsonApiAstraiosClient.ts
+++ b/packages/nexusgraph-astraios/src/JsonApiAstraiosClient.ts
@@ -62,7 +62,7 @@ export class JsonApiAstraiosClient implements AstraiosClient {
   }
 
   private isInitialSave(note: NoteState) {
-    return note.id === "";
+    return note.id === undefined;
   }
 
   private transformData(note: NoteState) {

--- a/packages/nexusgraph-redux/src/note/noteDuck.ts
+++ b/packages/nexusgraph-redux/src/note/noteDuck.ts
@@ -24,7 +24,6 @@ export const initialEditorContent: object = {
 };
 
 const initialState: NoteState = {
-  id: "",
   editorContent: initialEditorContent,
   graph: "",
 };

--- a/packages/nexusgraph-redux/src/note/noteTypes.ts
+++ b/packages/nexusgraph-redux/src/note/noteTypes.ts
@@ -6,7 +6,7 @@ export const UPDATE_NOTE_EDITOR_CONTENT = NOTE_STATE + "/UPDATE_NOTE_EDITOR_CONT
 export const CREATE_NEW_NOTE = NOTE_STATE + "/CREATE_NEW_NOTE";
 
 export interface NoteState {
-  id: string;
+  id?: string;
   editorContent: object;
   graph: string;
 }


### PR DESCRIPTION
Changelog
---------

### Added

### Changed
- Change the initial state of the id to `undefined` and define the property `id` in NoteState as an optional property
### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [ ] Test
* [x] Self-review
* [ ] Documentation
